### PR TITLE
fix: undefined method `grep' on ruby 2.2.1

### DIFF
--- a/delete_twitter_his.rb
+++ b/delete_twitter_his.rb
@@ -35,7 +35,7 @@ puts "どんな文字の含まれたツイートを消したいか入力して�
 delete = gets.chomp
 
 CSV.foreach("tweets.csv") do |tweets|
-  if tweets[5].grep(/(.+)?#{delete}(.+)?/) != []
+  if tweets[5].lines.grep(/(.+)?#{delete}(.+)?/) != []
 	at = tweets.first
 	begin
 	  print "id:#{at} "


### PR DESCRIPTION
（2.0から？）grepが直接呼び出せなくなっていたので．
http://takuya-1st.hatenablog.jp/entry/2013/10/15/012443

delete_twitter_his.rb:38:in `block in <main>': undefined method`grep' for "text":String (NoMethodError)
        from /usr/lib/ruby/2.2.0/csv.rb:1739:in `each'
        from /usr/lib/ruby/2.2.0/csv.rb:1122:in`block in foreach'
        from /usr/lib/ruby/2.2.0/csv.rb:1273:in `open'
        from /usr/lib/ruby/2.2.0/csv.rb:1121:in`foreach'
        from delete_twitter_his.rb:37:in `<main>'
